### PR TITLE
fix: work on ipv6 host

### DIFF
--- a/args.go
+++ b/args.go
@@ -77,6 +77,12 @@ func parseEnv() (opts Args, err error) {
 	if len(ss_local_host) == 0 {
 		return
 	}
+	if strings.IndexByte(ss_remote_host, ':') != -1 {
+	    ss_remote_host = "[" + ss_remote_host + "]"
+	}
+	if strings.IndexByte(ss_local_host, ':') != -1 {
+	    ss_local_host = "[" + ss_local_host + "]"
+	}
 
 	opts.Add("remoteAddr", ss_remote_host)
 	opts.Add("remotePort", ss_remote_port)


### PR DESCRIPTION
The env `SS_REMOTE_HOST` and `SS_LOCAL_HOST` without `[]` when IPv6, and rabbit-plugin will work error in that case.

```
~ # ss-libev-local -s ::1 -p 12345 -b 0.0.0.0 -l 1080 -k dnomd343 -m aes-256-ctr --plugin rabbit-plugin --plugin-opts "serviceAddr=127.0.0.1:20191;password=dnomd343"
 2022-03-05 03:02:53 INFO: plugin "rabbit-plugin" enabled
 2022-03-05 03:02:53 INFO: initializing ciphers... aes-256-ctr
 2022-03-05 03:02:53 INFO: Stream ciphers are insecure, therefore deprecated, and should be almost always avoided.
 2022-03-05 03:02:53 INFO: listening at 0.0.0.0:1080
 2022-03-05 03:02:53 INFO: running from root user
2022/03/05 03:02:53 Start in client mode
[ClientManager]2022/03/05 03:02:53 [Error] Error when dial to ::1:12345: dial tcp: address ::1:12345: too many colons in address.
2022/03/05 03:02:53 listen tcp: address ::1:51365: too many colons in address
 2022-03-05 03:02:53 ERROR: plugin service exit unexpectedly
 2022-03-05 03:02:53 INFO: error on terminating the plugin.
```